### PR TITLE
Desinstalando Lib que estava dando conflito com os Reducers

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "reactotron-redux": "^3.1.0",
     "reactotron-redux-saga": "^4.2.2",
     "redux": "^4.0.1",
-    "redux-persist": "^5.10.0",
     "redux-persist-transform-immutable": "^5.0.0",
     "redux-saga": "^1.0.2",
     "reduxsauce": "^1.1.0",

--- a/src/config/ReactotronConfig.js
+++ b/src/config/ReactotronConfig.js
@@ -4,6 +4,7 @@ import sagaPlugin from 'reactotron-redux-saga';
 
 if (__DEV__) {
   const tron = Reactotron.configure()
+    .useReactNative()
     .use(reactotronRedux())
     .use(sagaPlugin())
     .connect();

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,7 @@ import React from 'react';
 import '~/config/ReactotronConfig';
 
 import { Provider } from 'react-redux';
-import { PersistGate } from 'redux-persist/integration/react';
-import { store, persistor } from './store';
+import store from './store';
 
 import { setNavigator } from '~/services/navigation';
 
@@ -12,9 +11,7 @@ import Routes from '~/navigator';
 
 const App = () => (
   <Provider store={store}>
-    <PersistGate persistor={persistor} loading={null}>
-      <Routes ref={setNavigator} />
-    </PersistGate>
+    <Routes ref={setNavigator} />
   </Provider>
 );
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,5 @@
 import { createStore, compose, applyMiddleware } from 'redux';
 import createSagaMiddleware from 'redux-saga';
-import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import reducers from './ducks';
 import sagas from './sagas';
@@ -21,16 +19,8 @@ const composer = __DEV__
   )
   : compose(applyMiddleware(...middlewares));
 
-const persistConfig = {
-  key: 'root',
-  storage,
-};
-
-const persistedReducer = persistReducer(persistConfig, reducers);
-
-const store = createStore(persistedReducer, composer);
-const persistor = persistStore(store);
+const store = createStore(reducers, composer);
 
 sagaMiddleware.run(sagas);
 
-export { store, persistor };
+export default store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6276,11 +6276,6 @@ redux-persist-transform-immutable@^5.0.0:
   dependencies:
     remotedev-serialize "^0.1.0"
 
-redux-persist@^5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
-  integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
-
 redux-saga@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.0.2.tgz#0599703f975438f1b2f9d2b9a965ec58f0fdfcd7"


### PR DESCRIPTION
Foi desinstalado e desconfigurado o Redux Persist do projeto, pois o mesmo estava gerando conflito com o Seamless Immutable que cria o estado dos Reducers